### PR TITLE
Add CI/CD for PyPi

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,6 +1,8 @@
 name: Publish Python distribution to PyPI
 
-on: push
+on:
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,0 +1,52 @@
+name: Publish Python distribution to PyPI
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.9"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+#    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/eagle-test-graphs  # Replace <package-name> with your PyPI project name
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,11 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+GNU GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-                            Preamble
+Preamble
 
   The GNU General Public License is a free, copyleft license for
 software and other kinds of works.


### PR DESCRIPTION
I have added eagle-test-repo as a project on PyPi; this is necessary to have access to it in DALiuGE, as PyPi does not allow direct installations (i.e. from Github). 

This has also served as an opportunity to test pipeline deployment to PyPI as part of our transition to automating deployment. I have verified the pipeline deploys (on push), and have turned that so it should only trigger on release.

## Summary by Sourcery

Add a CI/CD workflow to automatically publish the package to PyPI on release.

CI:
- Add a CI workflow to automatically publish the package to PyPI on release.

Deployment:
- Configure the CI workflow to deploy the package to PyPI.