### PR TITLE
Release: version v0.2.3 🚀

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ release:          ## Create a new tag for release.
 	@git tag v$${TAG}
 	@git push -u --set-upstream origin $${TAG} --tags
 #	@echo "Github Actions will detect the new tag and release the new version."
-s
+
 # This Makefile has been based on the existing ICRAR/daliuge-component-template.
 # __author__ = 'ICRAR'
 # __repo__ = https://github.com/ICRAR/daliuge

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools.command.install import install
 
 setup(
     name="eagle-test-graphs",
-    version="0.2.2",
+    version="0.2.3",
     packages=find_packages(where="eagle_test_graphs"),
     package_dir={"": "eagle_test_graphs"},
     package_data={"": ["*.graph", "*.graphConfig", "*.pkl", "*.json", "*.spec"]},


### PR DESCRIPTION
## Summary by Sourcery

Prepare v0.2.3 release by updating package version and cleaning up the Makefile

Chores:
- Bump package version from 0.2.2 to 0.2.3 in setup.py
- Remove stray character in the Makefile