### PR TITLE
LIU-423: Remove graph pathname tuple

### DIFF
--- a/eagle_test_graphs/daliuge_tests/engine/graphs/SLURM_HelloWorld_simplePG.graph
+++ b/eagle_test_graphs/daliuge_tests/engine/graphs/SLURM_HelloWorld_simplePG.graph
@@ -1,1 +1,55 @@
-["SLURM_HelloWorld_simplePG.graph", [{"oid": "2022-03-24T11:40:15_-1_0", "categoryType": "Application", "dropclass": "dlg.apps.simple.HelloWorldApp", "rank": [0], "loop_ctx": null, "weight": 1, "num_cpus": 1, "greet": "Everybody", "execution_time": 1, "group_start": false, "applicationArgs": {}, "iid": "0", "lg_key": -1, "dt": "PythonApp", "name": "HelloWorldApp", "outputs": [{"2022-03-24T11:40:15_-2_0": "hello"}], "node": "localhost", "island": "localhost"}, {"oid": "2022-03-24T11:40:15_-2_0", "categoryType": "Data", "dropclass": "dlg.data.drops.file.FileDROP", "rank": [0], "loop_ctx": null, "weight": 5, "check_filepath_exists": "1", "filepath": "hello.txt", "data_volume": "5", "group_end": "0", "dirname": "", "applicationArgs": {}, "iid": "0", "lg_key": -2, "dt": "File", "name": "hello", "producers": [{"2022-03-24T11:40:15_-1_0": "hello"}], "node": "localhost", "island": "localhost"}]]
+[
+    {
+        "oid": "2022-03-24T11:40:15_-1_0",
+        "categoryType": "Application",
+        "dropclass": "dlg.apps.simple.HelloWorldApp",
+        "rank": [
+            0
+        ],
+        "loop_ctx": null,
+        "weight": 1,
+        "num_cpus": 1,
+        "greet": "Everybody",
+        "execution_time": 1,
+        "group_start": false,
+        "applicationArgs": {},
+        "iid": "0",
+        "lg_key": -1,
+        "dt": "PythonApp",
+        "name": "HelloWorldApp",
+        "outputs": [
+            {
+                "2022-03-24T11:40:15_-2_0": "hello"
+            }
+        ],
+        "node": "localhost",
+        "island": "localhost"
+    },
+    {
+        "oid": "2022-03-24T11:40:15_-2_0",
+        "categoryType": "Data",
+        "dropclass": "dlg.data.drops.file.FileDROP",
+        "rank": [
+            0
+        ],
+        "loop_ctx": null,
+        "weight": 5,
+        "check_filepath_exists": "1",
+        "filepath": "hello.txt",
+        "data_volume": "5",
+        "group_end": "0",
+        "dirname": "",
+        "applicationArgs": {},
+        "iid": "0",
+        "lg_key": -2,
+        "dt": "File",
+        "name": "hello",
+        "producers": [
+            {
+                "2022-03-24T11:40:15_-1_0": "hello"
+            }
+        ],
+        "node": "localhost",
+        "island": "localhost"
+    }
+]


### PR DESCRIPTION
We've removed the requirement for the SlurmClient to accept a physical graph file that is actually a tuple containing the path name and the actual physical graph (https://github.com/ICRAR/daliuge/pull/299). 

This updates the unittest file accordingly for test_slurm_client.py

## Summary by Sourcery

Tests:
- Adjust SLURM_HelloWorld_simplePG.graph test graph to match the updated SlurmClient interface that no longer requires a pathname/graph tuple.